### PR TITLE
fix handling of embedded simple types that aren't enumerations

### DIFF
--- a/contrib/test-range.xsd
+++ b/contrib/test-range.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0">
+  <xsd:complexType name="TestRangeInt">
+    <xsd:sequence>
+      <xsd:element name="value" minOccurs="0" maxOccurs="1">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:integer">
+            <xsd:minInclusive value="0" />
+            <xsd:maxInclusive value="60" />
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="TestRangeDecimal">
+    <xsd:sequence>
+      <xsd:element name="value" minOccurs="0" maxOccurs="1">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:decimal">
+            <xsd:minInclusive value="0.0" />
+            <xsd:maxInclusive value="1.0" />
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
@@ -370,16 +370,27 @@ public class XSDParser implements ErrorHandler {
      * @param elementName 
      */
     private String processSimpleType(XSSimpleType xs, String elementName) {
+
         String typeName = xs.getName();
         if (typeName == null) {
-            typeName = elementName != null ? elementName + "Type" : generateAnonymousName();
+            if (xs.getFacet("enumeration") != null) {
+                typeName = elementName != null ? elementName + "Type" : generateAnonymousName();
+            } else {
+		// can't use elementName here as it might not be unique (test-range.xsd)
+		typeName = generateAnonymousName();
+            }
         }
+
         if (xs.isRestriction() && xs.getFacet("enumeration") != null) {
             createEnum(typeName, xs.asRestriction());
         } else {
             //This is just a restriction on a basic type, find parent and map it to the type
-            while (xs != null && !basicTypes.contains(xs.getName())) {
+            String baseTypeName = typeName;
+            while (xs != null && !basicTypes.contains(baseTypeName)) {
                 xs = xs.getBaseType().asSimpleType();
+                if (xs != null) {
+                    baseTypeName = xs.getName();
+                }
             }
             simpleTypes.put(typeName, xs != null ? xs.getName() : "string");
         }


### PR DESCRIPTION
Embedded simple types resulted in initial xs.getName() == null.
TreeSet.contains(null) throws an Exception.

Since elementNames are often not unique for non-enumerations, I changed
the typeName to something that was unique so TestRangeInt.value and
TestRangeDecimal.value would be different types.
