### PR TITLE
Add support for child attributes in generated output for base type

### DIFF
--- a/contrib/test-extension-attributes.xsd
+++ b/contrib/test-extension-attributes.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0">
+    <xsd:complexType name="BaseObject">
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="1" />
+            <xsd:element name="description" type="xsd:string" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="StringObject">
+        <xsd:complexContent>
+            <xsd:restriction base="BaseObject">
+                <xsd:sequence>
+                    <xsd:element name="value" type="xsd:string" />
+                </xsd:sequence>
+                <xsd:attribute name="value2_required_attr" type="xsd:string" use="required" />
+                <xsd:attribute name="value3_optional_attr" type="xsd:string" use="optional" />
+            </xsd:restriction>
+        </xsd:complexContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
@@ -603,14 +603,38 @@ public class XSDParser implements ErrorHandler {
 		Iterator<XSType> ity;
 		XSType xt;
 		XSParticle particle;
+		XSComplexType type;
+		Iterator<? extends XSAttributeUse> itau;
+		XSAttributeUse att;
+		XSAttributeDecl decl;
+		Iterator<? extends XSAttGroupDecl> itagd;
 
 		ity = sset.iterateTypes();
 		while (ity.hasNext()) {
 			xt = ity.next();
 			if (xt.getBaseType() == cType) {
-				particle = xt.asComplexType().getContentType().asParticle();
+				// NOTE: the below code is almost identical to the contents of
+				// the write() function which takes an XSComplexType argument -
+				// the only difference is in the "goingup" variable passed to
+				// the other write() functions internally
+				
+				type = xt.asComplexType();
+				
+				particle = type.getContentType().asParticle();
 				if (particle != null) {
 					write(st, particle.getTerm(), false, sset);
+				}
+
+				itagd = type.getAttGroups().iterator();
+				while (itagd.hasNext()) {
+					write(st, itagd.next(), false);
+				}
+
+				itau = type.getAttributeUses().iterator();
+				while (itau.hasNext()) {
+					att = itau.next();
+					decl = att.getDecl();
+					write(st, decl, false);
 				}
 
 				processInheritance(st, xt.asComplexType(), sset);

--- a/src/test/data/expected/test-extension-attributes.proto
+++ b/src/test/data/expected/test-extension-attributes.proto
@@ -1,0 +1,26 @@
+package default;
+
+message UnspecifiedType
+{
+	required string baseObjectType = 1;
+	required bytes object = 2;
+}
+
+message BaseObject
+{
+	optional string description = 1;
+	required string name = 2;
+	optional string value = 3;
+	optional string value2_required_attr = 4;
+	optional string value3_optional_attr = 5;
+}
+
+message StringObject
+{
+	optional string description = 1;
+	required string name = 2;
+	required string value = 3;
+	required string value2_required_attr = 4;
+	optional string value3_optional_attr = 5;
+}
+

--- a/src/test/data/expected/test-extension-attributes.thrift
+++ b/src/test/data/expected/test-extension-attributes.thrift
@@ -1,0 +1,26 @@
+namespace * default
+
+struct UnspecifiedType
+{
+	1 : required string baseObjectType,
+	2 : required binary object,
+}
+
+struct BaseObject
+{
+	1 : optional string description,
+	2 : required string name,
+	3 : optional string value,
+	4 : optional string value2_required_attr,
+	5 : optional string value3_optional_attr,
+}
+
+struct StringObject
+{
+	1 : optional string description,
+	2 : required string name,
+	3 : required string value,
+	4 : required string value2_required_attr,
+	5 : optional string value3_optional_attr,
+}
+

--- a/src/test/java/com/github/tranchis/xsd2thrift/MainTest.java
+++ b/src/test/java/com/github/tranchis/xsd2thrift/MainTest.java
@@ -141,6 +141,20 @@ public class MainTest {
 	}
 
 	@Test
+	public void compareTestExtensionAttributesProtobuf() {
+		compareExpectedAndGenerated(
+				"src/test/data/expected/test-extension-attributes.proto",
+				generateProtobuf("test-extension-attributes"));
+	}
+
+	@Test
+	public void compareTestExtensionAttributesThrift() {
+		compareExpectedAndGenerated(
+				"src/test/data/expected/test-extension-attributes.thrift",
+				generateThrift("test-extension-attributes"));
+	}
+
+	@Test
 	public void compareTestOptionalProtobuf() {
 		compareExpectedAndGenerated(
 				"src/test/data/expected/test-optional.proto",


### PR DESCRIPTION
This is a proposed fix for issue #20, if it is agreed to be a defect. I added a test case for the scenario. 

I am a user of this tool, and this fix solves my problem - but I am not 100% sure if it is the proper thing for everyone! Please let me know what you think.

Thanks,
Brian
