### PR TITLE
Implement protobuf 3 support and unprefixed enums

### DIFF
--- a/src/main/java/com/github/tranchis/xsd2thrift/Main.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/Main.java
@@ -44,6 +44,8 @@ public class Main {
 			+ "  --nestEnums=true|false      : nest enum declaration within messages that reference them, only supported by protobuf, defaults to true\n"
 			+ "  --splitBySchema=true|false  : split output into namespace-specific files, defaults to false\n"
 			+ "  --customMappings=a:b,x:y    : represent schema types as specific output types\n"
+			+ "  --protobufVersion=2|3       : if generating protobuf, choose the version (2 or 3)\n"
+			+ "  --typeInEnums=true|false    : include type as a prefix in enums, defaults to true\n"
 			+ "";
 
 	private static void usage(String error) {
@@ -65,6 +67,8 @@ public class Main {
 		TreeMap<String, String> map;
 		String xsd, param;
 		int i;
+		int protobufVersion = 2;
+		ProtobufMarshaller pbm = null;
 		IMarshaller im;
 		OutputWriter writer;
 		correct = true;
@@ -104,10 +108,12 @@ public class Main {
 					}
 				} else if (args[i].equals("--protobuf")) {
 					if (im == null) {
-						im = new ProtobufMarshaller();
+						pbm = new ProtobufMarshaller();
+						im = pbm;
 						xp.addMarshaller(im);
 						writer.setMarshaller(im);
 						writer.setDefaultExtension("proto");
+						pbm.setProtobufVersion(protobufVersion);
 					} else {
 						usage("Only one marshaller can be specified at a time.");
 					}
@@ -140,6 +146,14 @@ public class Main {
 					param = args[i].split("=")[1];
 					boolean nestEnums = Boolean.valueOf(param);
 					xp.setNestEnums(nestEnums);
+				} else if (args[i].startsWith("--protobufVersion=")) {
+					protobufVersion = Integer.parseInt(args[i].split("=")[1]);
+					xp.setEnumOrderStart(0);
+					if (pbm != null) {
+						pbm.setProtobufVersion(protobufVersion);
+					}
+				} else if (args[i].startsWith("--typeInEnums=")) {
+					xp.setTypeInEnums(Boolean.parseBoolean(args[i].split("=")[1]));
 				} else {
 					usage();
 				}

--- a/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
@@ -66,6 +66,8 @@ public class XSDParser implements ErrorHandler {
 	private IMarshaller marshaller;
 	private OutputWriter writer;
 	private boolean nestEnums = true;
+	private int enumOrderStart = 1;
+	private boolean typeInEnums = true;
 
 	public XSDParser(String stFile) {
 		this.xsdMapping = new TreeMap<String, String>();
@@ -315,20 +317,25 @@ public class XSDParser implements ErrorHandler {
 		os(en.getNamespace()).write(
 				marshaller.writeEnumHeader(enumValue).getBytes());
 		itg = en.iterator();
-		int enumOrder = 1;
-
+		int enumOrder = this.enumOrderStart;
+		String typePrefix;
+		if (typeInEnums) {
+			typePrefix = en.getName() + "_";
+		} else {
+			typePrefix = "";
+		}
 		if (itg.hasNext()) {
 			while (itg.hasNext()) {
 				os(en.getNamespace()).write(
 						marshaller.writeEnumValue(enumOrder,
-								escape(en.getName() + "_" + itg.next()))
+								escape(typePrefix + itg.next()))
 								.getBytes());
 				enumOrder++;
 			}
 		} else {
 			os(en.getNamespace()).write(
 					marshaller.writeEnumValue(enumOrder,
-							escape(en.getName() + "_UnspecifiedValue"))
+							escape(typePrefix + "UnspecifiedValue"))
 							.getBytes());
 		}
 
@@ -729,4 +736,11 @@ public class XSDParser implements ErrorHandler {
 		this.writer = writer;
 	}
 
+	public void setEnumOrderStart(int enumOrderStart) {
+		this.enumOrderStart = enumOrderStart;
+	}
+
+	public void setTypeInEnums(boolean typeInEnums) {
+		this.typeInEnums = typeInEnums;
+	}
 }

--- a/src/main/java/com/github/tranchis/xsd2thrift/marshal/ProtobufMarshaller.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/marshal/ProtobufMarshaller.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 public class ProtobufMarshaller implements IMarshaller {
 	private TreeMap<String, String> typeMapping;
 	private String indent = "";
+	private int version = 2;
 
 	public ProtobufMarshaller() {
 		typeMapping = new TreeMap<String, String>();
@@ -109,11 +110,18 @@ public class ProtobufMarshaller implements IMarshaller {
 	@Override
 	public String writeStructParameter(int order, boolean required,
 			boolean repeated, String name, String type) {
-		String sRequired;
+		String sRequired = "";
 
-		sRequired = getRequired(required, repeated);
+		// Only versions prior to 3 have required/optional
+		if (version < 3) {
+			sRequired = getRequired(required, repeated) + " ";
+		} else {
+			if (repeated) {
+				sRequired = "repeated ";
+			}
+		}
 
-		return writeIndent() + sRequired + " " + type + " " + name + " = "
+		return writeIndent() + sRequired + type + " " + name + " = "
 				+ order + ";\n";
 	}
 
@@ -189,4 +197,7 @@ public class ProtobufMarshaller implements IMarshaller {
 		}
 	}
 
+	public void setProtobufVersion(int version) {
+		 this.version = version;
+	}
 }


### PR DESCRIPTION
Implement support for protobuf version 3 where there are no
optional or mandatory fields and enums start at 0. Also implement
support for enums that are not type prefixed as this is not needed
normally for protobuf.

Using default options there has been no change in output.