### PR TITLE
Provide xsd:duration

### DIFF
--- a/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/XSDParser.java
@@ -115,6 +115,7 @@ public class XSDParser implements ErrorHandler {
 		basicTypes.add("boolean");
 		basicTypes.add("date");
 		basicTypes.add("dateTime");
+		basicTypes.add("duration");
 		basicTypes.add("decimal");
 		basicTypes.add("float");
 		basicTypes.add("double");

--- a/src/main/java/com/github/tranchis/xsd2thrift/marshal/ProtobufMarshaller.java
+++ b/src/main/java/com/github/tranchis/xsd2thrift/marshal/ProtobufMarshaller.java
@@ -65,6 +65,7 @@ public class ProtobufMarshaller implements IMarshaller {
 											// 1970
 		typeMapping.put("dateTime", "int64"); // Number of milliseconds since
 												// January 1st, 1970
+		typeMapping.put("duration", "int64"); // Number of seconds during a period.
 	}
 
 	@Override


### PR DESCRIPTION
Provide duration to avoid error in compilation with a xsd schema, which contains duration.